### PR TITLE
Dashboard Pagination (branch→dev)

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -205,26 +205,19 @@ class App extends Component {
     }
   };
 
-  // loadMessage = (userObj) => {
     loadMessage = (userObj, pageNumber) => {
     if (pageNumber === undefined) {pageNumber = 1};
-    // const pageNumber = pageNumber;
-    // console.log('pagenumber', pageNumber)
-    const limit = 20;
     this.setState({
       ...this.state,
       discussionMessagesLoading: true,
     });
-    Axios.get(`/api/discussionMessages/${userObj.homeId}?page=${pageNumber}&limit=60`)
-    // Axios.get(`/api/discussionMessages/${userObj.homeId}`)
+    Axios.get(`/api/discussionMessages/${userObj.homeId}?page=${pageNumber}&limit=20`)
       .then((response) => {
-        // setTimeout(() => {
           this.setState({
             discussionMessages: response.data,
             messagesInitLoad: true,
             discussionMessagesLoading: false,
           });
-        // }, 1000);
       })
       .catch((error) => {
         this.setState({
@@ -234,29 +227,6 @@ class App extends Component {
       });
   };
 
-  loadNextMessage = (userObj) => {
-    this.setState({
-      ...this.state,
-      discussionMessagesLoading: true,
-    });
-    // Axios.get(`/api/discussionMessages/${userObj.homeId}?page=${}`)
-    Axios.get(`/api/discussionMessages/${userObj.homeId}`)
-      .then((response) => {
-        // setTimeout(() => {
-          this.setState({
-            discussionMessages: response.data,
-            messagesInitLoad: true,
-            discussionMessagesLoading: false,
-          });
-        // }, 1000);
-      })
-      .catch((error) => {
-        this.setState({
-          discussionMessagesLoading: false,
-        });
-        alert(error);
-      });
-  };
 
   appendMessage = async (message) => {
     let newMessage = {
@@ -559,6 +529,7 @@ class App extends Component {
                       setDMs={this.setDMs}
                       updateUserData={this.updateUserData}
                       getAllUsers={this.getAllUsers}
+                      currentPage={this.currentPage}
                       loadMessage={this.loadMessage}
                     />
                   </div>
@@ -733,6 +704,7 @@ function ToggleScreen({
   setDMs,
   updateUserData,
   getAllUsers,
+  currentPage,
   loadMessage,
 }) {
   if (name === 'Dashboard') {
@@ -747,8 +719,8 @@ function ToggleScreen({
           userObj={appState.userObj}
           removeMessage={removeMessage}
           postsPerPage={20}
-          currentPage={appState.currentPage}
-          // onPageChange={this.onChange}
+          // currentPage={appState.currentPage}
+          currentPage={1}
           loadMessage={loadMessage}
         />
         

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -37,6 +37,7 @@ import ManageTraining from './components/ManageTraining/ManageTraining';
 import { isAdminUser } from './utils/AdminReportingRoles';
 import NightMonitoring from './components/Forms/NightMonitoring';
 
+
 const hideStyle = {
   display: 'none',
 };
@@ -77,7 +78,12 @@ class App extends Component {
     },
     flip: false,
     showMessageSent: false,
+    loading: false,
+    
   };
+  
+
+
 
   doFetchFormApprovalCount = async () => {
     try {
@@ -177,13 +183,17 @@ class App extends Component {
     }
   };
 
-  componentDidUpdate = () => {
+  callGetAllUsers = () => {
     if (
       this.state.loggedIn &&
       (this.state.allUsersSet === false || this.state.allUsers.length === 0)
     ) {
       this.getAllUsers();
     }
+  }
+
+  componentDidUpdate = () => {
+    setTimeout((callGetAllUsers) => {}, 10000)
 
     if (
       !this.state.messagesInitLoad &&
@@ -201,13 +211,13 @@ class App extends Component {
     });
     Axios.get(`/api/discussionMessages/${userObj.homeId}`)
       .then((response) => {
-        setTimeout(() => {
+        // setTimeout(() => {
           this.setState({
             discussionMessages: response.data,
             messagesInitLoad: true,
             discussionMessagesLoading: false,
           });
-        }, 1000);
+        // }, 1000);
       })
       .catch((error) => {
         this.setState({
@@ -216,7 +226,6 @@ class App extends Component {
         alert(error);
       });
   };
-
   appendMessage = async (message) => {
     let newMessage = {
       message: message,
@@ -695,6 +704,7 @@ function ToggleScreen({
   if (name === 'Dashboard') {
     return (
       <div>
+        
         <MessageBoard
           discussionMessagesLoading={discussionMessagesLoading}
           messages={appState.discussionMessages}
@@ -702,7 +712,9 @@ function ToggleScreen({
           toggleDisplay={toggleDisplay}
           userObj={appState.userObj}
           removeMessage={removeMessage}
+          postsPerPage={20}
         />
+        
       </div>
     );
   }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -79,6 +79,7 @@ class App extends Component {
     flip: false,
     showMessageSent: false,
     loading: false,
+    currentPage: 1,
     
   };
   
@@ -204,11 +205,41 @@ class App extends Component {
     }
   };
 
-  loadMessage = (userObj) => {
+  // loadMessage = (userObj) => {
+    loadMessage = (userObj, pageNumber) => {
+    if (pageNumber === undefined) {pageNumber = 1};
+    // const pageNumber = pageNumber;
+    // console.log('pagenumber', pageNumber)
+    const limit = 20;
     this.setState({
       ...this.state,
       discussionMessagesLoading: true,
     });
+    Axios.get(`/api/discussionMessages/${userObj.homeId}?page=${pageNumber}&limit=60`)
+    // Axios.get(`/api/discussionMessages/${userObj.homeId}`)
+      .then((response) => {
+        // setTimeout(() => {
+          this.setState({
+            discussionMessages: response.data,
+            messagesInitLoad: true,
+            discussionMessagesLoading: false,
+          });
+        // }, 1000);
+      })
+      .catch((error) => {
+        this.setState({
+          discussionMessagesLoading: false,
+        });
+        alert(error);
+      });
+  };
+
+  loadNextMessage = (userObj) => {
+    this.setState({
+      ...this.state,
+      discussionMessagesLoading: true,
+    });
+    // Axios.get(`/api/discussionMessages/${userObj.homeId}?page=${}`)
     Axios.get(`/api/discussionMessages/${userObj.homeId}`)
       .then((response) => {
         // setTimeout(() => {
@@ -226,6 +257,7 @@ class App extends Component {
         alert(error);
       });
   };
+
   appendMessage = async (message) => {
     let newMessage = {
       message: message,
@@ -527,6 +559,7 @@ class App extends Component {
                       setDMs={this.setDMs}
                       updateUserData={this.updateUserData}
                       getAllUsers={this.getAllUsers}
+                      loadMessage={this.loadMessage}
                     />
                   </div>
                 </div>
@@ -700,6 +733,7 @@ function ToggleScreen({
   setDMs,
   updateUserData,
   getAllUsers,
+  loadMessage,
 }) {
   if (name === 'Dashboard') {
     return (
@@ -713,6 +747,9 @@ function ToggleScreen({
           userObj={appState.userObj}
           removeMessage={removeMessage}
           postsPerPage={20}
+          currentPage={appState.currentPage}
+          // onPageChange={this.onChange}
+          loadMessage={loadMessage}
         />
         
       </div>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -721,7 +721,6 @@ function ToggleScreen({
           removeMessage={removeMessage}
           postsPerPage={20}
           currentPage={appState.currentPage}
-          // currentPage={1}
           loadMessage={loadMessage}
         />
         

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -720,8 +720,8 @@ function ToggleScreen({
           userObj={appState.userObj}
           removeMessage={removeMessage}
           postsPerPage={20}
-          // currentPage={appState.currentPage}
-          currentPage={1}
+          currentPage={appState.currentPage}
+          // currentPage={1}
           loadMessage={loadMessage}
         />
         

--- a/client/src/components/DirectMessageBoard/DirectMessageBoard.css
+++ b/client/src/components/DirectMessageBoard/DirectMessageBoard.css
@@ -1,7 +1,7 @@
 /* desktop */
 @media only screen and (min-width: 1226px) {
   #messageBoard {
-    margin-top: 50px;
+    margin-top: 10px;
     width: 100%;
     background-color: white;
 
@@ -38,7 +38,7 @@
 /* ipad */
 @media only screen and (min-width: 768px) and (max-width: 1225px) {
   #messageBoard {
-    margin-top: 50px;
+    margin-top: 10px;
     width: 100%;
     background-color: white;
 

--- a/client/src/components/Forms/FormSubmitterListContainer.js
+++ b/client/src/components/Forms/FormSubmitterListContainer.js
@@ -64,6 +64,11 @@ class FormSubmitterListContainer extends Component {
     }
   }
 
+  disablePrint() {
+    console.log('submissions', this.props.submittions)
+    return (this.props.submittions.find(submission => submission.status === 'COMPLETED')) !== undefined
+  }
+
   triggerPrint = () => {
     this.state.formsLoaded = false;
     /*
@@ -165,14 +170,26 @@ class FormSubmitterListContainer extends Component {
             )}
           </div>
           )} */}
-        <div className="hide-on-print" style={{ paddingBottom: '10px', display: 'flex', alignItems: 'center', justifyContent: 'center', pageBreakBefore:"avoid", pageBreakInside:"avoid"}}>
-          <button onClick={this.triggerPrint}
-            className='btn btn-link'
-            // disable button if no completed forms
-            disabled={(this.props.submittions.find(submission => submission.status === 'COMPLETED')) !== undefined ? false : true}
-          >
-            <span className='fa fa-print'></span> Print {this.props.formType} Forms
-          </button>
+        <div className="hide-on-print" style={{ paddingBottom: '10px', display: 'flex', alignItems: 'center', justifyContent: 'center', pageBreakBefore: "avoid", pageBreakInside: "avoid" }}>
+          {this.props.submittions.find(submission => submission.status === 'COMPLETED') ?
+            <button onClick={this.triggerPrint}
+              className='btn btn-link'
+            >
+              <span className='fa fa-print'></span> Print {this.props.formType} Forms
+            </button>
+            :
+            // show tooltip if print button disabled
+            <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="No completed forms to print." style={{ display: "none" }}>
+              <button onClick={this.triggerPrint}
+                className='btn btn-link'
+                // disable button if no completed forms
+                disabled={(this.props.submittions.find(submission => submission.status === 'COMPLETED')) !== undefined ? false : true}
+              >
+                <span className='fa fa-print'></span> Print {this.props.formType} Forms
+              </button>
+            </span>
+          }
+
         </div>
         {this.props.submittions.length > 0 ? (
           this.props.submittions.map((form, formIndex) => (

--- a/client/src/components/MessageBoard/MessageBoard.css
+++ b/client/src/components/MessageBoard/MessageBoard.css
@@ -1,3 +1,13 @@
+.page-link {
+  height: auto;
+  width: 50px;
+  margin: 3px;
+  color: black;
+}
+.active {
+  background-color: maroon;
+  color: white;
+}
 /* desktop */
 @media only screen and (min-width: 1226px) {
   #messageBoard {

--- a/client/src/components/MessageBoard/MessageBoard.css
+++ b/client/src/components/MessageBoard/MessageBoard.css
@@ -1,3 +1,6 @@
+#recentPageBtn {
+  width:100px;
+}
 .page-link {
   height: auto;
   width: 50px;
@@ -11,7 +14,7 @@
 /* desktop */
 @media only screen and (min-width: 1226px) {
   #messageBoard {
-    margin-top: 50px;
+    margin-top: 10px;
     width: 100%;
     background-color: white;
 
@@ -48,7 +51,7 @@
 /* ipad */
 @media only screen and (min-width: 768px) and (max-width: 1225px) {
   #messageBoard {
-    margin-top: 50px;
+    margin-top: 10px;
     width: 100%;
     background-color: white;
 

--- a/client/src/components/MessageBoard/MessageBoard.js
+++ b/client/src/components/MessageBoard/MessageBoard.js
@@ -55,10 +55,12 @@ class MessageBoard extends Component {
   }
 
   handlePagination = (pageNumber) => {
-    let firstIndex = (((this.state.currentPage) - 1) * 20);
-    this.setState({currentPage: pageNumber});
+    this.state.currentPage = pageNumber;
+    this.props.loadMessage(this.props.userObj, pageNumber)
+    let firstIndex = (((this.props.currentPage) - 1) * 20);
+    // this.setState({currentPage: pageNumber});
     this.setState({indexOfFirstPost: firstIndex})
-    this.setState({indexOfLastPost: (this.state.currentPage*20) - 1 })
+    this.setState({indexOfLastPost: (this.props.currentPage*20) - 1 })
   };
 
   openModal = (modalName) => {
@@ -145,13 +147,15 @@ class MessageBoard extends Component {
         length={this.props.messages.length}
         postsPerPage={this.state.postsPerPage}
         handlePagination={this.handlePagination}
-        currentPage={this.state.currentPage}
+        currentPage={this.props.currentPage}
+        loadMessage={this.props.loadMessage}
+        userObj={this.props.userObj}
       />
         }
         
         <ContentAfterLoad
           removeMessage={this.props.removeMessage}
-          messages={this.props.messages.slice(((this.state.currentPage-1)*this.state.postsPerPage), ((this.state.currentPage*this.state.postsPerPage)-1))}
+          messages={this.props.messages.slice(((this.props.currentPage-1)*this.state.postsPerPage), ((this.props.currentPage*this.state.postsPerPage)-1))}
           isLoading={this.props.discussionMessagesLoading}
           userObj={this.props.userObj}
         />

--- a/client/src/components/MessageBoard/MessageBoard.js
+++ b/client/src/components/MessageBoard/MessageBoard.js
@@ -5,6 +5,8 @@ import "./MessageBoard.css";
 import "../../App.css";
 import ClipLoader from "react-spinners/ClipLoader";
 import { isAdminUser } from "../../utils/AdminReportingRoles";
+import Pagination from "./Pagination";
+
 
 const ContentAfterLoad = ({ messages, isLoading, removeMessage, userObj }) => {
   const [currentMessages, setCurrentMessage] = useState(messages);
@@ -34,6 +36,7 @@ const ContentAfterLoad = ({ messages, isLoading, removeMessage, userObj }) => {
           {item.message}
         </MessagePost>
       ))}
+
     </div>
   );
 };
@@ -44,8 +47,19 @@ class MessageBoard extends Component {
     this.state = {
       showModal: "",
       messageText: "",
-    };
+      postsPerPage: 20,
+      currentPage: 1,
+      indexOfFirstPost: 0,
+      indexOfLastPost: 19,
+       };
   }
+
+  handlePagination = (pageNumber) => {
+    let firstIndex = (((this.state.currentPage) - 1) * 20);
+    this.setState({currentPage: pageNumber});
+    this.setState({indexOfFirstPost: firstIndex})
+    this.setState({indexOfLastPost: (this.state.currentPage*20) - 1 })
+  };
 
   openModal = (modalName) => {
     this.setState({ showModal: modalName });
@@ -125,9 +139,15 @@ class MessageBoard extends Component {
             </div>
           </>
         )}
+        <Pagination
+          length={this.props.messages.length}
+          postsPerPage={this.state.postsPerPage}
+          handlePagination={this.handlePagination}
+          currentPage={this.state.currentPage}
+        />
         <ContentAfterLoad
           removeMessage={this.props.removeMessage}
-          messages={this.props.messages}
+          messages={this.props.messages.slice(((this.state.currentPage-1)*20), ((this.state.currentPage*20)-1))}
           isLoading={this.props.discussionMessagesLoading}
           userObj={this.props.userObj}
         />

--- a/client/src/components/MessageBoard/MessageBoard.js
+++ b/client/src/components/MessageBoard/MessageBoard.js
@@ -63,6 +63,21 @@ class MessageBoard extends Component {
     this.setState({indexOfLastPost: (this.props.currentPage*20) - 1 })
   };
 
+  recentPageMessage = () => {
+    this.state.currentPage = 1;
+    this.props.loadMessage(this.props.userObj, this.state.currentPage)
+  }
+
+  nextPageMessage = () => {
+    this.state.currentPage += 1;
+    this.props.loadMessage(this.props.userObj, this.state.currentPage)
+  }
+
+  prevPageMessage = () => {
+    this.state.currentPage -= 1;
+    this.props.loadMessage(this.props.userObj, this.state.currentPage)
+  }
+
   openModal = (modalName) => {
     this.setState({ showModal: modalName });
   };
@@ -146,8 +161,10 @@ class MessageBoard extends Component {
         <Pagination
         length={this.props.messages.length}
         postsPerPage={this.state.postsPerPage}
-        handlePagination={this.handlePagination}
-        currentPage={this.props.currentPage}
+        prevPageMessage = {this.prevPageMessage}
+        nextPageMessage = {this.nextPageMessage}
+        recentPageMessage = {this.recentPageMessage}
+        currentPage={this.state.currentPage}
         loadMessage={this.props.loadMessage}
         userObj={this.props.userObj}
       />

--- a/client/src/components/MessageBoard/MessageBoard.js
+++ b/client/src/components/MessageBoard/MessageBoard.js
@@ -139,15 +139,19 @@ class MessageBoard extends Component {
             </div>
           </>
         )}
+        {/* hide pagination on load */}
+        {!this.props.discussionMessagesLoading && 
         <Pagination
-          length={this.props.messages.length}
-          postsPerPage={this.state.postsPerPage}
-          handlePagination={this.handlePagination}
-          currentPage={this.state.currentPage}
-        />
+        length={this.props.messages.length}
+        postsPerPage={this.state.postsPerPage}
+        handlePagination={this.handlePagination}
+        currentPage={this.state.currentPage}
+      />
+        }
+        
         <ContentAfterLoad
           removeMessage={this.props.removeMessage}
-          messages={this.props.messages.slice(((this.state.currentPage-1)*20), ((this.state.currentPage*20)-1))}
+          messages={this.props.messages.slice(((this.state.currentPage-1)*this.state.postsPerPage), ((this.state.currentPage*this.state.postsPerPage)-1))}
           isLoading={this.props.discussionMessagesLoading}
           userObj={this.props.userObj}
         />

--- a/client/src/components/MessageBoard/Pagination.js
+++ b/client/src/components/MessageBoard/Pagination.js
@@ -60,7 +60,7 @@ const Pagination = ({
                 <li className="page-item">
                     <a
                         onClick={() => nextPage()}
-                        className={'btn btn-light page-link'}
+                        className={pageButtonTotal <= pageButtonCount ? 'btn btn-light page-link disabled' : 'btn btn-light page-link'}
                         id={'nextPageBtn'}
                     >
                         &rarr;

--- a/client/src/components/MessageBoard/Pagination.js
+++ b/client/src/components/MessageBoard/Pagination.js
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import "./MessageBoard.css";
+import "../../App.css";
+
+const Pagination = ({
+    postsPerPage,
+    length,
+    handlePagination,
+    currentPage,
+}) => {
+    let pageButtonCount = 5;
+    let pageButtonTotal = length / postsPerPage;
+    let [startIndex, setStartIndex] = useState(0);
+    let [endIndex, setEndIndex] = useState(pageButtonCount);
+
+    let paginationNumber = [];
+    const nextPage = () => {
+        setStartIndex(startIndex += pageButtonCount);
+        setEndIndex(endIndex += pageButtonCount);
+        document.getElementById("prevPageBtn").classList.remove('disabled');
+        pageButtonTotal<endIndex && document.getElementById("nextPageBtn").classList.add('disabled');
+    }
+    const prevPage = () => {
+        setStartIndex(startIndex -= pageButtonCount);
+        setEndIndex(endIndex -= pageButtonCount);
+        document.getElementById("nextPageBtn").classList.remove('disabled');
+        startIndex === 0 && document.getElementById("prevPageBtn").classList.add('disabled')
+    }
+
+    for (let i = 1; i <= Math.ceil(length / postsPerPage); i++) {
+        if (i <= endIndex && i > startIndex) {
+            paginationNumber.push(i)
+        }
+    }
+
+
+    return (
+        <ul id='pagination' className="pagination">
+                <li className="page-item">
+                    <a
+                        onClick={() => prevPage()}
+                        className={'btn btn-light page-link disabled'}
+                        id={'prevPageBtn'}
+                    >
+                        &larr;
+                    </a>
+                </li>
+            {paginationNumber.map((data) => (
+                <li className="page-item">
+                    <a
+                        key={data}
+                        onClick={() => handlePagination(data)}
+                        className={currentPage === data ? 'active btn page-link' : 'btn btn-light page-link'}
+                    >
+                        {data}
+                    </a>
+                </li>
+            ))
+            }
+                <li className="page-item">
+                    <a
+                        onClick={() => nextPage()}
+                        className={'btn btn-light page-link'}
+                        id={'nextPageBtn'}
+                    >
+                        &rarr;
+                    </a>
+                </li>
+        </ul>
+    )
+}
+export default Pagination

--- a/client/src/components/MessageBoard/Pagination.js
+++ b/client/src/components/MessageBoard/Pagination.js
@@ -3,71 +3,59 @@ import "./MessageBoard.css";
 import "../../App.css";
 
 const Pagination = ({
-    postsPerPage,
-    length,
-    handlePagination,
+    nextPageMessage,
+    recentPageMessage,
+    prevPageMessage,
     currentPage,
-    loadMessage,
-    userObj
 }) => {
-    let pageButtonCount = 5;
-    let pageButtonTotal = length / postsPerPage;
-    let [startIndex, setStartIndex] = useState(0);
-    let [endIndex, setEndIndex] = useState(pageButtonCount);
 
-    let paginationNumber = [];
+    const recentPage = () => {
+        currentPage = 1;
+        recentPageMessage();
+    }
+
     const nextPage = () => {
-        setStartIndex(startIndex += pageButtonCount);
-        setEndIndex(endIndex += pageButtonCount);
-        document.getElementById("prevPageBtn").classList.remove('disabled');
-        pageButtonTotal<endIndex && document.getElementById("nextPageBtn").classList.add('disabled');
+        currentPage += 1;
+        nextPageMessage();
     }
+
     const prevPage = () => {
-        setStartIndex(startIndex -= pageButtonCount);
-        setEndIndex(endIndex -= pageButtonCount);
-        document.getElementById("nextPageBtn").classList.remove('disabled');
-        startIndex === 0 && document.getElementById("prevPageBtn").classList.add('disabled')
+        currentPage -= 1;
+        prevPageMessage();
     }
-
-    for (let i = 1; i <= Math.ceil(length / postsPerPage); i++) {
-        if (i <= endIndex && i > startIndex) {
-            paginationNumber.push(i)
-        }
-    }
-
 
     return (
         <ul id='pagination' className="pagination">
-                <li className="page-item">
-                    <a
-                        onClick={() => prevPage()}
-                        className={'btn btn-light page-link disabled'}
-                        id={'prevPageBtn'}
-                    >
-                        &larr;
-                    </a>
-                </li>
-            {paginationNumber.map((data) => (
-                <li className="page-item">
-                    <a
-                        key={data}
-                        onClick={() => handlePagination(data)}
-                        className={currentPage === data ? 'active btn page-link' : 'btn btn-light page-link'}
-                    >
-                        {data}
-                    </a>
-                </li>
-            ))
-            }
-                <li className="page-item">
-                    <a
-                        onClick={() => nextPage()}
-                        className={pageButtonTotal <= pageButtonCount ? 'btn btn-light page-link disabled' : 'btn btn-light page-link'}
-                        id={'nextPageBtn'}
-                    >
-                        &rarr;
-                    </a>
-                </li>
+
+            <li className="page-item">
+                <a
+                    onClick={() => recentPage()}
+                    className= {currentPage === 1 ? 'btn btn-light page-link disabled' : 'btn btn-light page-link'}
+                    id={'recentPageBtn'}
+                >
+                    Recent
+                </a>
+            </li>
+
+            <li className="page-item">
+                <a
+                    onClick={() => prevPage()}
+                    className= {currentPage === 1 ? 'btn btn-light page-link disabled' : 'btn btn-light page-link'}
+                    id={'prevPageBtn'}
+                >
+                    &larr;
+                </a>
+            </li>
+
+            <li className="page-item">
+                <a
+                    onClick={() => nextPage()}
+                    className='btn btn-light page-link'
+                    id={'nextPageBtn'}
+                >
+                    &rarr;
+                </a>
+            </li>
         </ul>
     )
 }

--- a/client/src/components/MessageBoard/Pagination.js
+++ b/client/src/components/MessageBoard/Pagination.js
@@ -7,6 +7,8 @@ const Pagination = ({
     length,
     handlePagination,
     currentPage,
+    loadMessage,
+    userObj
 }) => {
     let pageButtonCount = 5;
     let pageButtonTotal = length / postsPerPage;

--- a/client/src/components/Reports/FormReports.js
+++ b/client/src/components/Reports/FormReports.js
@@ -111,6 +111,7 @@ export class FormReports extends Component {
       showFullForms: false,
       formsToPrint: [],
       formsLoaded: false,
+      disablePrint: true,
     };
   }
   openPrintModal = () => {
@@ -196,6 +197,7 @@ export class FormReports extends Component {
     var startBarChartData = this.state.barChartData;
     data.forEach((formData) => {
       if (formData.length > 0) {
+        var statusByFormType = formData.map((status) => status.status)
         //add to form state
         let nestedFormObj = {
           name: formData[0].formType,
@@ -208,6 +210,10 @@ export class FormReports extends Component {
           name: formData[0].formType,
           submittions: formData.length,
         });
+        // if at least one form with completed status, enable print button
+        if (this.state.disablePrint === true && statusByFormType.find((status)=>status === 'COMPLETED')) {
+          this.setState({disablePrint: false}) 
+        }
       }
       count++;
       if (count === promiseCount) {
@@ -1199,9 +1205,26 @@ export class FormReports extends Component {
                   </button>
                 )}
                 {!this.state.doShowFilters && (
-                  <button onClick={this.triggerPrint} className='btn btn-link'>
+                  !this.state.disablePrint ?
+                  <button 
+                    onClick={this.triggerPrint} 
+                    className='btn btn-link'
+                  >
                     <span className='fa fa-print'></span> Print Results
                   </button>
+                  :
+                  // show tooltip if print button disabled
+                  <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="No completed forms to print."
+                    style={{display: this.state.disablePrint ? "none" : "block"}}> 
+                  <button 
+                    onClick={this.triggerPrint} 
+                    className='btn btn-link'
+                    // disable button if no completed forms
+                    disabled={this.state.disablePrint ? true : false}
+                  >
+                    <span className='fa fa-print'></span> Print Results
+                  </button>
+                  </span>
                 )}
               </div>
             </h2>

--- a/routes/api/discussionMessages.js
+++ b/routes/api/discussionMessages.js
@@ -9,7 +9,6 @@ router.get("/:homeId", (req, res) => {
   const limit = req.query.limit;
   const startIndex = (page-1)*limit;
   const endIndex = page*limit;
-  // const result = discussionMessage.slice(startIndex, endIndex)
   if (req.params.homeId) {
     console.log(
       `Get Discussion Messages for home ${req.params.homeId} - start`

--- a/routes/api/discussionMessages.js
+++ b/routes/api/discussionMessages.js
@@ -5,6 +5,11 @@ const router = express.Router();
 const DiscussionMessage = require("../../models/DiscussionMessage");
 
 router.get("/:homeId", (req, res) => {
+  const page = req.query.page;
+  const limit = req.query.limit;
+  const startIndex = (page-1)*limit;
+  const endIndex = page*limit;
+  // const result = discussionMessage.slice(startIndex, endIndex)
   if (req.params.homeId) {
     console.log(
       `Get Discussion Messages for home ${req.params.homeId} - start`
@@ -15,7 +20,7 @@ router.get("/:homeId", (req, res) => {
         console.log(
           `getting Discussion Messages for home - ${req.params.homeId} - end`
         );
-        res.json(discussionMessage);
+        res.json(discussionMessage.slice(startIndex, endIndex));
       });
   } else {
     console.log(`Getting Discussion Messages for every home - start`);
@@ -23,7 +28,7 @@ router.get("/:homeId", (req, res) => {
       .sort({ date: -1 })
       .then((discussionMessage) => {
         console.log(`Discussion Messages for every home - end `);
-        res.json(discussionMessage);
+        res.json(discussionMessage.slice(startIndex, endIndex));
       });
   }
 });


### PR DESCRIPTION
- put timeout on call to users, reduced calls by 3. speeds up loading a tad.
- pagination calls 20 messages on load. arrow button to load next 20 messages. (note: switched to arrows instead of numbers so no unnecessary calls are made)
- tooltip displayed on disabled print buttons to let user know there are no completed forms to print. 

<img width="741" alt="image" src="https://github.com/ecare-software/ecare-residential/assets/58446979/11b15e0e-64f6-4cad-ae1f-4ebee005693c">

<img width="971" alt="image" src="https://github.com/ecare-software/ecare-residential/assets/58446979/ac1beda8-2d37-45b7-8ebd-d51564f83525">