### PR TITLE
Signature Box & Display 'Explain the Incident'

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -47,6 +47,16 @@
   }
 }
 
+#sigCanvasDiv {
+  height: 100px;
+  display: flex;
+  padding-bottom: 20px;
+}
+
+.sigSection {
+  padding-left: 15px;
+}
+
 td{
   width: 20%;
 }
@@ -173,10 +183,11 @@ input {
   border-radius: 11px;
 }
 
-.sigCanvas {
-  width: 90%;
-  padding-bottom: 10px;
-}
+/* .sigCanvas {
+  width: 300px;
+  padding-bottom: 0px;
+  height: 50px;
+} */
 
 .extraInfoMainTitle {
   font-weight: 300;
@@ -579,6 +590,10 @@ html {
     font-family: "Google Sans Display", Arial, Helvetica, sans-serif;
     font-size: 2em;
   }
+
+  #summary_of_daily_schedule-row {
+    margin-top: -30px;
+  }
 }
 
 /* ipad */
@@ -738,6 +753,10 @@ html {
     height: 400px;
     width: 300px;
     position: relative;
+  }
+
+  #summary_of_daily_schedule-row {
+    margin-top: -30px;
   }
 }
 

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -45,6 +45,10 @@
     text-align: left;
     width: 250px
   }
+  
+  #summary_of_daily_schedule-row {
+    margin-top: -30px;
+  }
 }
 
 #sigCanvasDiv {

--- a/client/src/components/Forms/AdmissionAssessment.js
+++ b/client/src/components/Forms/AdmissionAssessment.js
@@ -3959,15 +3959,8 @@ class AdmissionAssessment extends Component {
             <div className="sigSection"
               style={{ display: this.state.status === 'IN PROGRESS' ? 'none' : 'block' }}
             >
-              <label className="control-label">Signature</label>
-              <div
-                style={{
-                  width: "100%",
-                  display: "flex",
-                  maxHeight: "170",
-                  paddingBottom: "20px",
-                }}
-              >
+              <label className="control-label">Signature</label>{" "}
+              <div id='sigCanvasDiv'>
                 <SignatureCanvas
                   ref={(ref) => {
                     this.sigCanvas = ref;
@@ -3976,7 +3969,7 @@ class AdmissionAssessment extends Component {
                   penColor="black"
                   clearOnResize={false}
                   canvasProps={{
-                    width: 600,
+                    width: 300,
                     height: 100,
                     className: "sigCanvas",
                   }}

--- a/client/src/components/Forms/BodyCheck.js
+++ b/client/src/components/Forms/BodyCheck.js
@@ -2403,14 +2403,7 @@ class BodyCheck extends Component {
               style={{ display: this.state.status === 'IN PROGRESS' ? 'none' : 'block' }}
             >
               <label className="control-label">Signature</label>{" "}
-              <div
-                style={{
-                  width: "100%",
-                  display: "flex",
-                  maxHeight: "170",
-                  paddingBottom: "20px",
-                }}
-              >
+              <div id='sigCanvasDiv'>
                 <SignatureCanvas
                   ref={(ref) => {
                     this.sigCanvas = ref;
@@ -2419,7 +2412,7 @@ class BodyCheck extends Component {
                   penColor="black"
                   clearOnResize={false}
                   canvasProps={{
-                    width: 600,
+                    width: 300,
                     height: 100,
                     className: "sigCanvas",
                   }}

--- a/client/src/components/Forms/DailyProgressAndActivity.js
+++ b/client/src/components/Forms/DailyProgressAndActivity.js
@@ -1472,7 +1472,7 @@ class DailyProgressAndActivity extends Component {
                     </div>
                   </Col>
                 </Row>
-                <Row>
+                <Row id='summary_of_daily_schedule-row'>
                   <Col md={12} className="print-column">
                     <div className="form-group logInInputField" >
                       {" "}
@@ -1500,14 +1500,7 @@ class DailyProgressAndActivity extends Component {
               style={{ display: this.state.status === 'IN PROGRESS' ? 'none' : 'block' }}
             >
               <label className="control-label">Signature</label>{" "}
-              <div
-                style={{
-                  width: "100%",
-                  display: "flex",
-                  maxHeight: "170",
-                  paddingBottom: "20px",
-                }}
-              >
+              <div id='sigCanvasDiv'>
                 <SignatureCanvas
                   ref={(ref) => {
                     this.sigCanvas = ref;
@@ -1516,7 +1509,7 @@ class DailyProgressAndActivity extends Component {
                   penColor="black"
                   clearOnResize={false}
                   canvasProps={{
-                    width: 600,
+                    width: 300,
                     height: 100,
                     className: "sigCanvas",
                   }}

--- a/client/src/components/Forms/IllnessInjury.js
+++ b/client/src/components/Forms/IllnessInjury.js
@@ -874,14 +874,7 @@ class IllnessInjury extends Component {
               style={{ display: this.state.status === 'IN PROGRESS' ? 'none' : 'block' }}
             >
               <label className="control-label">Signature</label>{" "}
-              <div
-                style={{
-                  width: "100%",
-                  display: "flex",
-                  maxHeight: "170",
-                  paddingBottom: "20px",
-                }}
-              >
+              <div id='sigCanvasDiv'>
                 <SignatureCanvas
                   ref={(ref) => {
                     this.sigCanvas = ref;
@@ -890,7 +883,7 @@ class IllnessInjury extends Component {
                   penColor="black"
                   clearOnResize={false}
                   canvasProps={{
-                    width: 600,
+                    width: 300,
                     height: 100,
                     className: "sigCanvas",
                   }}

--- a/client/src/components/Forms/IncidentReport.js
+++ b/client/src/components/Forms/IncidentReport.js
@@ -1349,12 +1349,17 @@ class IncidentReport extends Component {
                       <label className="control-label">
                         Explain the Incident
                       </label>{" "}
-                      <TextareaAutosize
-                        onChange={this.handleFieldInput}
-                        value={this.state.incident_explaination}
-                        id="incident_explaination"
-                        className="form-control"
-                      ></TextareaAutosize>
+                      <div className='hide-on-print'>
+                        <TextareaAutosize
+                          onChange={this.handleFieldInput}
+                          value={this.state.incident_explaination}
+                          id="incident_explaination"
+                          className="form-control"
+                        ></TextareaAutosize>
+                      </div>
+                      <p className="hide-on-non-print">
+                        {this.state.incident_explaination}
+                      </p>
                     </div>
                   </Col>
                 </Row>
@@ -1484,11 +1489,7 @@ class IncidentReport extends Component {
               style={{ display: this.state.status === 'IN PROGRESS' ? 'none' : 'block' }}
             >
               <label className="control-label">Signature</label>{" "}
-              <div
-                style={{
-                  width: "100%", display: "flex", maxHeight: "170", paddingBottom: "20px",
-                }}
-              >
+              <div id='sigCanvasDiv'>
                 <SignatureCanvas
                   ref={(ref) => {
                     this.sigCanvas = ref;
@@ -1497,7 +1498,7 @@ class IncidentReport extends Component {
                   penColor="black"
                   clearOnResize={false}
                   canvasProps={{
-                    width: 600, height: 100, className: "sigCanvas",
+                    width: 300, height: 100, className: "sigCanvas",
                   }}
                   backgroundColor="#eeee"
                 />

--- a/client/src/components/Forms/NightMonitoring.js
+++ b/client/src/components/Forms/NightMonitoring.js
@@ -464,32 +464,7 @@ class NightMonitoring extends Component {
                 />
               </div>
             )}
-            {/* <label className="control-label">Signature</label>{" "}
-            <div className="sigSection">
-              <div
-                style={{
-                 width: "100%",
-                  display: "flex",
-maxHeight:"170",
-                  justifyContent: "center",
-                }}
-              >
-                <SignatureCanvas
-                  ref={(ref) => {
-                    this.sigCanvas = ref;
-                  }}
-                  style={{ border: "solid" }}
-                  penColor="black"
-                  clearOnResize={false}
-                  canvasProps={{
-                    width: 600,
-                    height: 100,
-                    className: "sigCanvas",
-                  }}
-                  backgroundColor="#eeee"
-                />
-              </div>
-            </div> */}
+
             {!this.props.formData.approved && (
               <>
                 <FormError errorId={this.props.id + "-error"} />

--- a/client/src/components/Forms/RestraintReport.js
+++ b/client/src/components/Forms/RestraintReport.js
@@ -1835,14 +1835,7 @@ class RestraintReport extends Component {
               style={{ display: this.state.status === 'IN PROGRESS' ? 'none' : 'block' }}
             >
               <label className="control-label">Signature</label>{" "}
-              <div
-                style={{
-                  width: "100%",
-                  display: "flex",
-                  maxHeight: "170",
-                  paddingBottom: "20px",
-                }}
-              >
+              <div id='sigCanvasDiv'>
                 <SignatureCanvas
                   ref={(ref) => {
                     this.sigCanvas = ref;
@@ -1851,7 +1844,7 @@ class RestraintReport extends Component {
                   penColor="black"
                   clearOnResize={false}
                   canvasProps={{
-                    width: 600,
+                    width: 300,
                     height: 100,
                     className: "sigCanvas",
                   }}

--- a/client/src/components/Forms/SeriousIncidentReport.js
+++ b/client/src/components/Forms/SeriousIncidentReport.js
@@ -1407,14 +1407,7 @@ class SeriousIncidentReport extends Component {
               style={{ display: this.state.status === 'IN PROGRESS' ? 'none' : 'block' }}
             >
               <label className="control-label">Signature</label>{" "}
-              <div
-                style={{
-                  width: "100%",
-                  display: "flex",
-                  maxHeight: "170",
-                  paddingBottom: "20px",
-                }}
-              >
+              <div id='sigCanvasDiv'>
                 <SignatureCanvas
                   ref={(ref) => {
                     this.sigCanvas = ref;
@@ -1423,7 +1416,7 @@ class SeriousIncidentReport extends Component {
                   penColor="black"
                   clearOnResize={false}
                   canvasProps={{
-                    width: 600,
+                    width: 300,
                     height: 100,
                     className: "sigCanvas",
                   }}

--- a/client/src/components/Forms/TreatmentPlan72.js
+++ b/client/src/components/Forms/TreatmentPlan72.js
@@ -4541,14 +4541,7 @@ class TreatmentPlan72 extends Component {
             style={{ display: this.state.status === 'IN PROGRESS' ? 'none' : 'block' }}
           >
             <label className="control-label">Signature</label>{" "}
-            <div
-              style={{
-                width: "100%",
-                display: "flex",
-                maxHeight: "170",
-                paddingBottom: "20px",
-              }}
-            >
+            <div id='sigCanvasDiv'>
               <SignatureCanvas
                 ref={(ref) => {
                   this.sigCanvas = ref;
@@ -4557,7 +4550,7 @@ class TreatmentPlan72 extends Component {
                 penColor="black"
                 clearOnResize={false}
                 canvasProps={{
-                  width: 600,
+                  width: 300,
                   height: 100,
                   className: "sigCanvas",
                 }}

--- a/client/src/components/NightMonitoringChildRow.js
+++ b/client/src/components/NightMonitoringChildRow.js
@@ -26,6 +26,7 @@ export const NightMonitoringChildRow = ({
   );
   const [childSelected, setChildSelected] = useState(rootState?.childSelected);
   const [formSubmitted, setFormSubmitted] = useState(rootState?.formSubmitted);
+  const [status, setStatus] = useState(rootState?.status);
 
   let sigCanvas;
   const doFormatChildMetaName = (val) => {
@@ -59,6 +60,7 @@ export const NightMonitoringChildRow = ({
       childMeta_name,
       childSelected,
       formSubmitted,
+      status
     });
   }, [
     date,
@@ -70,6 +72,7 @@ export const NightMonitoringChildRow = ({
     childMeta_name,
     childSelected,
     formSubmitted,
+    status
   ]);
 
   return (
@@ -94,7 +97,7 @@ export const NightMonitoringChildRow = ({
                   defaultValue={childMeta_name}
                   className="form-control"
                   type="text"
-                  disabled = {childSelected ? true : false}
+                  disabled={childSelected ? true : false}
                 />
               ) : (
                 <Form.Control
@@ -125,7 +128,7 @@ export const NightMonitoringChildRow = ({
                 id="date"
                 defaultValue={date}
                 className="form-control"
-                disabled = {childSelected ? false : true}
+                disabled={childSelected ? false : true}
                 type="date"
               />{" "}
             </div>
@@ -141,7 +144,7 @@ export const NightMonitoringChildRow = ({
                 id="roomNumber"
                 defaultValue={roomNumber}
                 className="form-control"
-                disabled = {childSelected ? false : true}
+                disabled={childSelected ? false : true}
                 type="text"
               />{" "}
             </div>
@@ -158,7 +161,7 @@ export const NightMonitoringChildRow = ({
                 id="timeChildAwake"
                 defaultValue={timeChildAwake}
                 className="form-control"
-                disabled = {childSelected ? false : true}
+                disabled={childSelected ? false : true}
                 type="time"
               />{" "}
             </div>
@@ -176,7 +179,7 @@ export const NightMonitoringChildRow = ({
                 id="timeChildReturnBed"
                 defaultValue={timeChildReturnBed}
                 className="form-control"
-                disabled = {childSelected ? false : true}
+                disabled={childSelected ? false : true}
                 type="time"
               />{" "}
             </div>
@@ -194,68 +197,33 @@ export const NightMonitoringChildRow = ({
                 id="reason"
                 defaultValue={reason}
                 className="form-control"
-                disabled = {childSelected ? false : true}
+                disabled={childSelected ? false : true}
                 type="text"
               ></TextareaAutosize>
             </div>
           </Col>
-          <Col md="6" className="control-label text-center sigSection">
-            {signed ? (
-              <div className="mb-2 d-flex align-items-center">
-                {
-                  <a
-                    href="javascript:void(0)"
-                    className="hide-on-print"
-                    onClick={() => {
-                      setSigned(false);
-                    }}
-                  >
-                    Signed. Remove signature?
-                  </a>
-                }
-              </div>
-            ) : (
-              <Form.Check
-                type="checkbox"
-                className="mb-2 hide-on-print d-flex align-items-center justify-content-space-between"
-                label={valuesSet ? "Not Completed or Signed" : "Click to sign"}
-                onClick={() => {
-                  setSigned(true);
-                  console.log(sigCanvas);
-                  if (signature && signature.length) {
-                    sigCanvas.fromData(signature);
-                    sigCanvas.off();
-                  }
-                }}
-              />
-            )}
-          </Col>
-          <div 
-            style={{
-              width: "100%",
-              display: "flex",
-              maxHeight: "170",
-              justifyContent: "center",
-              display: signed ? "" : "none",
-              paddingRight: "15px",
-              
-            }}
+          <div className="sigSection"
+            style={{ display: status === 'IN PROGRESS' ? 'none' : 'block' }}
           >
-            <SignatureCanvas
-              ref={(ref) => {
-                sigCanvas = ref;
-              }}
-              style={{ border: "solid",}}
-              penColor="black"
-              clearOnResize={false}
-              canvasProps={{
-                width: 600,
-                height: 100,
-                className: "sigCanvas",
-              }}
-              backgroundColor="#eeee"
-            />
-          </div>
+          <label className="control-label">Signature</label>{" "}
+          <div id='sigCanvasDiv'>
+              <SignatureCanvas
+                ref={(ref) => {
+                  sigCanvas = ref;
+                }}
+                style={{ border: "solid", }}
+                penColor="black"
+                clearOnResize={false}
+                canvasProps={{
+                  width: 300,
+                  height: 100,
+                  className: "sigCanvas",
+                }}
+                backgroundColor="#eeee"
+              />
+              </div>
+            </div>
+          {/* </div> */}
         </Row>
       </Col>
     </Row>

--- a/client/src/components/Reports/ShowFormContainer.js
+++ b/client/src/components/Reports/ShowFormContainer.js
@@ -427,12 +427,8 @@ const MetaDetails = ({ formData, isAdminRole, route, userObj }) => {
         )}
         <Form.Row style={{pageBreakAfter: "avoid"}}>
           <Col xs="auto" style={{pageBreakAfter: "avoid"}}>
-            <div
+            <div id='sigCanvasDiv'
               style={{
-                width: "100%",
-                display: "flex",
-                maxHeight: "170",
-                justifyContent: "center",
                 display: !isSavingSigCanvasAdmin && isApproved ? "" : "none",
                 pageBreakAfter: "avoid"
               }}
@@ -445,7 +441,7 @@ const MetaDetails = ({ formData, isAdminRole, route, userObj }) => {
                 penColor="black"
                 clearOnResize={false}
                 canvasProps={{
-                  width: 600,
+                  width: 300,
                   height: 100,
                   className: "sigCanvasAdmin",
                 }}


### PR DESCRIPTION
- formatted signature boxes to the exact size they are currently drawn as (NOTE: it seems like some users need to re-draw their signatures)
- reduced size of signature boxes
- display all text entered into 'Explain the Incident' field during print 
- removed 'click to sign' functionality on Awake Night Monitoring form & replaced with signature auto displaying upon submission

<img width="464" alt="image" src="https://github.com/ecare-software/ecare-residential/assets/58446979/457dba40-bee7-4072-9151-8f4043c21512">

my user signature (traced box size upon creation):
<img width="620" alt="image" src="https://github.com/ecare-software/ecare-residential/assets/58446979/876a8000-2a06-4e5e-9293-d3241fb15d05">
<img width="462" alt="image" src="https://github.com/ecare-software/ecare-residential/assets/58446979/aa544506-d134-441e-b14e-023d8d6be1f6">

