### PR TITLE
Night Monitor Form Displays Creator Signature

### DIFF
--- a/client/src/components/Forms/NightMonitoring.js
+++ b/client/src/components/Forms/NightMonitoring.js
@@ -240,7 +240,7 @@ class NightMonitoring extends Component {
       ...this.props.formData,
       loadingSig: false,
       loadingClients: false,
-      signature: this.props.userObj.signature,
+      signature: createdUserData.signature,
     });
   };
 
@@ -371,7 +371,7 @@ class NightMonitoring extends Component {
                 setRootState={this.setRootState}
                 rootState={this.state}
                 clients={this.state.clients}
-                signature={this.props.userObj.signature}
+                signature={this.state.signature}
               />
               <FormError errorId={this.props.id + "-error"} />
 

--- a/client/src/components/NightMonitoringChildRow.js
+++ b/client/src/components/NightMonitoringChildRow.js
@@ -43,7 +43,6 @@ export const NightMonitoringChildRow = ({
     if (signature && signature.length) {
       sigCanvas.fromData(signature);
       sigCanvas.off();
-      console.log('sig & sig.length')
     }
   }, [signature]);
 

--- a/client/src/components/NightMonitoringChildRow.js
+++ b/client/src/components/NightMonitoringChildRow.js
@@ -43,6 +43,7 @@ export const NightMonitoringChildRow = ({
     if (signature && signature.length) {
       sigCanvas.fromData(signature);
       sigCanvas.off();
+      console.log('sig & sig.length')
     }
   }, [signature]);
 

--- a/client/src/components/Reports/ShowFormContainer.js
+++ b/client/src/components/Reports/ShowFormContainer.js
@@ -342,7 +342,7 @@ const MetaDetails = ({ formData, isAdminRole, route, userObj }) => {
         </h6>
       </div>
       <div className="d-flex align-items-center hide-on-print">
-        <h6 style={{ fontWeight: 400, marginRight: 5 }}>Created Date</h6>{" "}
+        <h6 style={{ fontWeight: 400, marginRight: 5 }}>Created</h6>{" "}
         <h6 style={{ fontWeight: 300 }}>
           {` ${formData.createdByName}, ${
             formData.createdByName


### PR DESCRIPTION
- Display signature of user who created the Night Monitoring form when form is completed.
- Above all forms, changed 'Created Date' to 'Created' because created by name and date is displayed 

<img width="728" alt="image" src="https://github.com/user-attachments/assets/1b7af45d-97b9-4a42-96bf-ea0c71aefd56">
